### PR TITLE
refactor: loginService redis 활용하도록 수정

### DIFF
--- a/src/main/java/hey/io/heybackend/common/config/RedisConfig.java
+++ b/src/main/java/hey/io/heybackend/common/config/RedisConfig.java
@@ -1,0 +1,44 @@
+package hey.io.heybackend.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@EnableRedisRepositories
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration =
+            new RedisStandaloneConfiguration(host, port);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+
+
+}

--- a/src/main/java/hey/io/heybackend/common/config/SecurityConfig.java
+++ b/src/main/java/hey/io/heybackend/common/config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/health_check").permitAll() // Swagger 경로 허용
                         .requestMatchers("/access").permitAll() // 토큰 발급 기능 허용
                         .requestMatchers("/login/**").permitAll() // 로그인
+                        .requestMatchers("/register/**").permitAll() // 회원 가입
                         .requestMatchers("/performances/**").permitAll() // 공연 조회 기능 허용
                         .requestMatchers("/artists/**").permitAll() // 아티스트 조회 기능 허용
                         .requestMatchers("/main").permitAll() // 메인
@@ -120,4 +121,3 @@ public class SecurityConfig {
     }
 
 }
-

--- a/src/main/java/hey/io/heybackend/common/exception/ErrorCode.java
+++ b/src/main/java/hey/io/heybackend/common/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     QUERY_PARAMETER_REQUIRED(HttpStatus.BAD_REQUEST, "쿼리 파라미터가 필요한 API입니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
     PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"파싱에 실패했습니다."),
+    INVALID_KEY(HttpStatus.BAD_REQUEST, "Key값이 올바르지 않습니다."),
 
     // Authorization
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),

--- a/src/main/java/hey/io/heybackend/domain/user/service/RedisService.java
+++ b/src/main/java/hey/io/heybackend/domain/user/service/RedisService.java
@@ -1,0 +1,43 @@
+package hey.io.heybackend.domain.user.service;
+
+import hey.io.heybackend.domain.login.dto.SocialUserInfo;
+import java.time.Duration;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public String generateKey() {
+        String uuid = UUID.randomUUID().toString();
+        redisTemplate.opsForValue().set(uuid, "PENDING", Duration.ofMinutes(15));
+        return uuid;
+    }
+
+    public void deleteKey(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public void setSocialUserInfo(String key, SocialUserInfo socialUserInfo, Duration duration) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.set(key, socialUserInfo, duration);
+    }
+
+    public SocialUserInfo getSocialUserInfo(String key) {
+        SocialUserInfo jsonValue = (SocialUserInfo) redisTemplate.opsForValue().get(key);
+
+        if (ObjectUtils.isEmpty(jsonValue)) {
+            return null;
+        }
+
+        return jsonValue;
+    }
+
+}


### PR DESCRIPTION
## Description

> Redis를 활용한 사용자 로그인 및 소셜 계정 연동 비즈니스 로직 구현

## Progress

 **사용자 로그인 흐름**

사용자 로그인 페이지 진입 (일반 로그인 또는 소셜 로그인 화면 노출).
세션을 위한 Redis 토큰(혹은 고유 키) 발급.
토큰에 TTL(만료 시간) 설정.

**소셜 로그인 시도**

사용자가 소셜 로그인 시도 시, 토큰과 키를 함께 전달.
소셜 ID가 존재하는 경우: 로그인 처리 및 사용자 데이터 Redis에 저장.
소셜 ID가 존재하지 않는 경우: "계정이 존재하지 않습니다." 응답.

**회원가입 여부 확인 화면**

계정이 없으면 "회원가입 하시겠습니까?" 화면 노출.
확인 버튼 클릭 시 회원가입 페이지로 이동.
회원가입 처리

**사용자가 회원가입 폼을 작성.**
소셜 로그인으로 가입한 경우, 소셜 계정 자동 연동 처리.
회원 정보와 소셜 계정 연동을 위해 Redis 토큰을 사용하여 세션 추적.
